### PR TITLE
feat: Chisel the rock

### DIFF
--- a/insights_rock/rockcraft.yaml
+++ b/insights_rock/rockcraft.yaml
@@ -2,7 +2,7 @@ name: ubuntu-insights-server
 
 base: bare
 build-base: ubuntu@24.04
-version: "0.1.0"
+version: "0.2.0"
 license: GPL-3.0
 summary: Service for ubuntu-insights
 description: |
@@ -18,7 +18,7 @@ parts:
     web-service:
         plugin: go
         source: https://github.com/ubuntu/ubuntu-insights.git
-        source-tag: v0.1.0
+        source-tag: v0.2.0
         source-subdir: server/cmd/web-service
         stage-packages:
             - base-files
@@ -40,7 +40,7 @@ parts:
     ingest-service:
         plugin: go
         source: https://github.com/ubuntu/ubuntu-insights.git
-        source-tag: v0.1.0
+        source-tag: v0.2.0
         source-subdir: server/cmd/ingest-service
         stage-packages:
             - base-files
@@ -62,7 +62,7 @@ parts:
     migrations:
         plugin: dump
         source: https://github.com/ubuntu/ubuntu-insights.git
-        source-tag: v0.1.0
+        source-tag: v0.2.0
         source-subdir: server/migrations
         organize:
             "*": usr/share/insights/migrations/


### PR DESCRIPTION
This PR chiseles the rock, including just the required binaries as well as a basic file structure provided by `base-files`. 

Note I tried using `base-files_base` but it doesn't seem to be sufficient for whatever reason. But this switch with `base-files` from a base of `ubuntu@24.04` to `bare` results in a significant reduction in file size (and may also improve security by decreasing the surface area of an attack vector).