### PR TITLE
ci(renovate): Fix renovate commit messages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,8 +2,8 @@
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
         "config:recommended",
-        ":semanticCommits",
-        ":semanticCommitType(deps)",
-        ":semanticCommitScope({{manager}})"
-    ]
+        ":semanticCommitTypeAll(deps)"
+    ],
+    "semanticCommits": "enabled",
+    "semanticCommitScope": "{{manager}}"
 }


### PR DESCRIPTION
Fix renovate commit messages to use correct semantic commit types and scopes.

For working examples, see this fork here: https://github.com/hk21702/ubuntu-insights-k8s-operator/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen