### PR TITLE
refactor(database): Refactor database handling into its own module

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -1,0 +1,93 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Provides the DatabaseHandler class to handle database relation and state."""
+
+import logging
+from dataclasses import dataclass
+
+from charms.data_platform_libs.v0.data_interfaces import DatabaseRequires
+from ops import CharmBase, Object
+
+DATABASE_NAME = "insights"
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class DBData:
+    """Data class for database relation data."""
+
+    host: str = ""
+    port: str = ""
+    user: str = ""
+    password: str = ""
+    db_name: str = ""
+
+
+class DatabaseHandler(Object):
+    """The postgreSQL Database relation handler."""
+
+    def __init__(self, charm: CharmBase, relation_name: str):
+        """Initialize the handler and register event handlers.
+
+        Args:
+            charm: The charm instance.
+            relation_name: The name of the database relation.
+        """
+        super().__init__(charm, "database-observer")
+        self._charm = charm
+        self.relation_name = relation_name
+        self.database = DatabaseRequires(
+            self._charm,
+            relation_name=self.relation_name,
+            database_name=DATABASE_NAME,
+        )
+
+    def get_relation_data(self) -> DBData:
+        """Fetch the database relation data.
+
+        If the relation is not ready or data is missing, an empty DBData instance is returned.
+
+        Returns:
+            A DBData instance containing the database relation data.
+        """
+        if self.model.get_relation(self.relation_name) is None or len(self.database.relations) < 1:
+            logger.info("Could not find database relation: %s.", self.relation_name)
+            return DBData()
+
+        relation_id = self.database.relations[0].id
+        relation_data = self.database.fetch_relation_data()[relation_id]
+
+        endpoints = relation_data.get("endpoints", "").split(",")
+        primary_endpoint = endpoints[0].split(":")
+        if len(primary_endpoint) < 2:
+            logger.info(
+                "Could not parse primary endpoint from database relation data: %s", endpoints[0]
+            )
+            return DBData()
+
+        logger.info("Fetched database endpoint: %s", primary_endpoint)
+
+        if None in (
+            relation_data.get("username"),
+            relation_data.get("password"),
+            relation_data.get("database"),
+        ):
+            return DBData()
+
+        return DBData(
+            host=primary_endpoint[0],
+            port=primary_endpoint[1],
+            user=relation_data["username"],
+            password=relation_data["password"],
+            db_name=relation_data["database"],
+        )
+
+    def is_relation_ready(self) -> bool:
+        """Check if the database relation is ready.
+
+        Returns:
+            bool: True if the relation is ready, False otherwise.
+        """
+        return self.get_relation_data().host != ""

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -1,0 +1,105 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import contextlib
+from unittest.mock import MagicMock, PropertyMock, patch
+
+from database import DatabaseHandler, DBData
+
+
+def test_dbdata_defaults():
+    """Test that DBData defaults to empty strings."""
+    db = DBData()
+    assert db.host == ""
+    assert db.port == ""
+    assert db.user == ""
+    assert db.password == ""
+    assert db.db_name == ""
+
+
+def test_get_relation_data_no_relation():
+    """Test that get_relation_data returns empty DBData when no relation exists."""
+    charm = MagicMock()
+    handler = DatabaseHandler(charm, "database")
+    handler.model.get_relation = MagicMock(return_value=None)
+    assert handler.get_relation_data() == DBData()
+
+
+@contextlib.contextmanager
+def handler_with_mocked_relation(relation_data, relation_id=1):
+    charm = MagicMock()
+    handler = DatabaseHandler(charm, "database")
+    handler.model.get_relation = MagicMock(return_value=True)
+    with patch.object(
+        type(handler.database), "relations", new_callable=PropertyMock
+    ) as mock_relations:
+        mock_relations.return_value = [MagicMock(id=relation_id)]
+        handler.database.fetch_relation_data = MagicMock(return_value=relation_data)
+        yield handler
+
+
+def test_get_relation_data_no_endpoints():
+    """Test that get_relation_data returns empty DBData when no endpoints are found."""
+    with handler_with_mocked_relation({0: {}, 1: {"endpoints": ""}}, relation_id=0) as handler:
+        assert handler.get_relation_data() == DBData()
+
+    with handler_with_mocked_relation({1: {"endpoints": ""}}, relation_id=1) as handler:
+        assert handler.get_relation_data() == DBData()
+
+
+def test_get_relation_data_malformed_endpoint():
+    """Test that get_relation_data returns empty DBData when endpoints are malformed."""
+    with handler_with_mocked_relation({1: {"endpoints": "badendpoint"}}, relation_id=1) as handler:
+        assert handler.get_relation_data() == DBData()
+
+
+def test_get_relation_data_missing_fields():
+    with handler_with_mocked_relation(
+        {
+            1: {
+                "endpoints": "host:1234",
+                "username": None,
+                "password": None,
+                "database": None,
+            }
+        },
+        relation_id=1,
+    ) as handler:
+        assert handler.get_relation_data() == DBData()
+
+
+def test_get_relation_data_valid():
+    """Test that get_relation_data returns valid DBData when all fields are present and valid."""
+    with handler_with_mocked_relation(
+        {
+            1: {
+                "endpoints": "host:1234",
+                "username": "user",
+                "password": "pass",
+                "database": "db",
+            }
+        },
+        relation_id=1,
+    ) as handler:
+        db = handler.get_relation_data()
+        assert db.host == "host"
+        assert db.port == "1234"
+        assert db.user == "user"
+        assert db.password == "pass"
+        assert db.db_name == "db"
+
+
+def test_is_relation_ready_true():
+    """Test that is_relation_ready returns True when relation data is valid."""
+    charm = MagicMock()
+    handler = DatabaseHandler(charm, "database")
+    handler.get_relation_data = MagicMock(return_value=DBData(host="host"))
+    assert handler.is_relation_ready() is True
+
+
+def test_is_relation_ready_false():
+    """Test that is_relation_ready returns False when relation data is not valid."""
+    charm = MagicMock()
+    handler = DatabaseHandler(charm, "database")
+    handler.get_relation_data = MagicMock(return_value=DBData(host=""))
+    assert handler.is_relation_ready() is False


### PR DESCRIPTION
Refactor database handling into its own module for improved organization.
- Added DatabaseHandler class to encapsulate database relation logic.
- Introduced DBData dataclass for structured database relation data.
- Updated charm.py to utilize DatabaseHandler for database operations.
- Created unit tests for DatabaseHandler to ensure correct functionality.

Note that `logger.info` is often used instead of `logger.warning` as it is expected especially during initialization that the database relation will not be ready and some things are unparsable. The hope in using info instead of warning is to reduce log spam while still providing the info should it really be needed. Since these are technically triggered during a "broken" state, info is used instead of debug. 