### PR TITLE
tests(integration): Improve PostgreSQL deployment reliability

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -10,5 +10,7 @@ jobs:
     with:
       juju-channel: 3.6/stable
       channel: 1.32-strict/stable
-      runs-on: ubuntu-22.04 # Use Ubuntu 22.04 for the test environment as it is what is expected for deployment
+      self-hosted-runner: true
+      self-hosted-runner-image: jammy # Use Ubuntu 22.04 for the test environment as it is what is expected for deployment
+      self-hosted-runner-label: large
       modules: '["test_charm", "test_removal"]'

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -83,7 +83,7 @@ def app(juju: jubilant.Juju, metadata: Dict[str, Any], charm_file: str, image: s
     juju.deploy(
         charm="postgresql-k8s",
         channel="14/stable",
-        revision=400,
+        revision=495,
         trust=True,
         config={"profile": "testing"},
     )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -100,7 +100,10 @@ def app(juju: jubilant.Juju, metadata: Dict[str, Any], charm_file: str, image: s
     )
 
     # Wait for PostgreSQL to be ready
-    juju.wait(lambda status: jubilant.all_active(status, "postgresql-k8s"))
+    juju.wait(
+        lambda status: jubilant.all_active(status, "postgresql-k8s"),
+        timeout=20 * 60,
+    )
 
     status = juju.status()
     assert status.apps[app_name].units[app_name + "/0"].is_blocked

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -25,7 +25,7 @@ def juju(request: pytest.FixtureRequest):
 
     model = request.config.getoption("--model")
     if model:
-        juju = jubilant.Juju(model=model)
+        juju = jubilant.Juju(model=model, wait_timeout=10 * 60)
         yield juju
         show_debug_log(juju)
         return


### PR DESCRIPTION
This PR attempts to improve PostgreSQL deployment reliability.

Update the integration test workflow to use our self-hosted runners, which have more resources.

This PR also bumps the PostgreSQL revision being used to hopefully make the deployment of that less flaky as well.

The timeout for the PostgreSQL deployment has been explicitly set to 20 minutes.