### PR TITLE
feat: Add JSON logging and default to INFO

### DIFF
--- a/insights_rock/rockcraft.yaml
+++ b/insights_rock/rockcraft.yaml
@@ -2,7 +2,7 @@ name: ubuntu-insights-server
 
 base: bare
 build-base: ubuntu@24.04
-version: "0.6.0"
+version: "0.7.0"
 license: GPL-3.0
 summary: Service for ubuntu-insights
 description: |
@@ -18,7 +18,7 @@ parts:
     web-service:
         plugin: go
         source: https://github.com/ubuntu/ubuntu-insights.git
-        source-tag: v0.6.0
+        source-tag: server/v0.7.0
         source-subdir: server/cmd/web-service
         stage-packages:
             - base-files
@@ -40,7 +40,7 @@ parts:
     ingest-service:
         plugin: go
         source: https://github.com/ubuntu/ubuntu-insights.git
-        source-tag: v0.6.0
+        source-tag: server/v0.7.0
         source-subdir: server/cmd/ingest-service
         stage-packages:
             - base-files
@@ -62,7 +62,7 @@ parts:
     migrations:
         plugin: dump
         source: https://github.com/ubuntu/ubuntu-insights.git
-        source-tag: v0.6.0
+        source-tag: server/v0.7.0
         source-subdir: server/migrations
         organize:
             "*": usr/share/insights/migrations/

--- a/src/charm.py
+++ b/src/charm.py
@@ -327,7 +327,7 @@ class UbuntuInsightsCharm(ops.CharmBase):
     @property
     def _pebble_layer(self) -> ops.pebble.Layer:
         """Pebble layer for the web service."""
-        debug = "-vv" if self.config["debug"] else ""
+        debug = "-vv" if self.config["debug"] else "-v"
 
         web_command = " ".join(
             [

--- a/src/charm.py
+++ b/src/charm.py
@@ -332,8 +332,8 @@ class UbuntuInsightsCharm(ops.CharmBase):
         web_command = " ".join(
             [
                 "/bin/ubuntu-insights-web-service",
+                WEB_DYNAMIC_PATH,
                 f"--listen-port={self.config['web-port']}",
-                f"--daemon-config={WEB_DYNAMIC_PATH}",
                 f"--reports-dir={self.report_cache_path}",
                 f"--metrics-port={WEB_PROMETHEUS_PORT}",
                 debug,
@@ -343,7 +343,7 @@ class UbuntuInsightsCharm(ops.CharmBase):
         ingest_command = " ".join(
             [
                 "/bin/ubuntu-insights-ingest-service",
-                f"--daemon-config={INGEST_DYNAMIC_PATH}",
+                INGEST_DYNAMIC_PATH,
                 f"--reports-dir={self.report_cache_path}",
                 f"--metrics-port={INGEST_PROMETHEUS_PORT}",
                 debug,

--- a/src/charm.py
+++ b/src/charm.py
@@ -336,6 +336,7 @@ class UbuntuInsightsCharm(ops.CharmBase):
                 f"--listen-port={self.config['web-port']}",
                 f"--reports-dir={self.report_cache_path}",
                 f"--metrics-port={WEB_PROMETHEUS_PORT}",
+                "--json-logs",
                 debug,
             ]
         ).strip()
@@ -346,6 +347,7 @@ class UbuntuInsightsCharm(ops.CharmBase):
                 INGEST_DYNAMIC_PATH,
                 f"--reports-dir={self.report_cache_path}",
                 f"--metrics-port={INGEST_PROMETHEUS_PORT}",
+                "--json-logs",
                 debug,
             ]
         ).strip()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -46,10 +46,12 @@ def test_pebble_layer():
                 "summary": "web service",
                 "command": (
                     f"/bin/ubuntu-insights-web-service "
+                    f"{WEB_DYNAMIC_PATH} "
                     f"--listen-port=8080 "
-                    f"--daemon-config={WEB_DYNAMIC_PATH} "
                     f"--reports-dir={REPORTS_CACHE_MOUNT_LOCATION} "
-                    f"--metrics-port={WEB_PROMETHEUS_PORT}"
+                    f"--metrics-port={WEB_PROMETHEUS_PORT} "
+                    "--json-logs "
+                    "-v"
                 ),
                 "startup": "enabled",
             },
@@ -58,9 +60,11 @@ def test_pebble_layer():
                 "summary": "ingest service",
                 "command": (
                     f"/bin/ubuntu-insights-ingest-service "
-                    f"--daemon-config={INGEST_DYNAMIC_PATH} "
+                    f"{INGEST_DYNAMIC_PATH} "
                     f"--reports-dir={REPORTS_CACHE_MOUNT_LOCATION} "
-                    f"--metrics-port={INGEST_PROMETHEUS_PORT}"
+                    f"--metrics-port={INGEST_PROMETHEUS_PORT} "
+                    f"--json-logs "
+                    "-v"
                 ),
                 "startup": "disabled",
             },
@@ -206,10 +210,13 @@ def test_storage_attached():
     assert state_out.get_container(container.name).layers[container.name].services[
         ServiceType.WEB.value
     ].command == (
-        f"/bin/ubuntu-insights-web-service --listen-port=8080 "
-        f"--daemon-config={WEB_DYNAMIC_PATH} "
+        f"/bin/ubuntu-insights-web-service "
+        f"{WEB_DYNAMIC_PATH} "
+        "--listen-port=8080 "
         f"--reports-dir={REPORTS_CACHE_MOUNT_LOCATION} "
-        f"--metrics-port={WEB_PROMETHEUS_PORT}"
+        f"--metrics-port={WEB_PROMETHEUS_PORT} "
+        f"--json-logs "
+        "-v"
     )
 
 


### PR DESCRIPTION
This PR adds JSON logging and defaults to the INFO level. Additionally, it introduces some changes to the command used to start the services to conform with a breaking change introduced in version 0.7.0 of the workload.

As a note, by defaulting to the INFO level, there will be potentially up to four individual logs printed per report processed and ingested, though the average should be two. If this proves to be too much log ingest, then we can revisit this down the road, possibly on the workload side.

---
[UDENG-7663](https://warthogs.atlassian.net/browse/UDENG-7663)

[UDENG-7663]: https://warthogs.atlassian.net/browse/UDENG-7663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ