### PR TITLE
ci: Fix QServer Python dependency installation

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,8 +43,7 @@ jobs:
       - name: Install dependencies (QServer)
         if: steps.tics-condition.outputs.tics_mode == 'qserver'
         run: |
-          set -e
-          uv add --frozen flake8 Pylint
+          uv pip install flake8 Pylint
 
       - name: Run tests
         run: |


### PR DESCRIPTION
Installation of these dependencies should have been using `uv pip install` to install into the `.venv` instead of `uv add` which just adds to `pyproject.toml`.