### PR TITLE
ci: Split TiCS into its own job

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,12 +34,14 @@ jobs:
       - name: Run tests
         run: |
           tox
+          mkdir coverage
+          mv coverage.xml coverage/Cobertura.xml
 
       - name: Upload test artifacts
         uses: actions/upload-artifact@v4
         with:
           name: tests-${{ github.job }}-artifacts-${{ github.run_attempt }}
-          path: coverage.xml
+          path: ./coverage
 
       - name: Upload to codecov
         uses: codecov/codecov-action@v5
@@ -71,11 +73,6 @@ jobs:
         uses: actions/download-artifact@v5
         with:
           merge-multiple: true # There is only one artifact, but this removes the subfolder
-
-      - name: Prep coverage reports
-        shell: bash
-        run: |
-          mv coverage.xml Cobertura.xml
 
       - name: Determine TiCS run conditions
         id: tics-condition


### PR DESCRIPTION
Pylint and Flake8 should be installed as tools. But, since we used uv to install tox as a tool, the environmental variable as to where tools are installed was modified. This means that though pylint and flake8 are supposed to be pre-installed, TiCS doesn't pick them up.

To help resolve this, this PR splits the TiCS steps into their own job, independent from the actual running of the tests. This should help ensure a cleaner environment and also help with getting test results faster since the basic GitHub runners have better availability.

See the following run as an example of how Pylint is supposed to be invokable: https://github.com/canonical/ubuntu-insights-k8s-operator/actions/runs/17623260256/job/50073778910?pr=29

Additionally, this PR bumps the Setup Python action version.