### PR TITLE
ci: Fix coverage uploads and TiCS dependencies

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,11 +55,6 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version-file: "pyproject.toml"
-
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v6
         with:
@@ -68,6 +63,9 @@ jobs:
       - name: Install dependencies
         run: |
           uv sync --locked --all-extras --dev
+          source .venv/bin/activate
+          uv pip install flake8 pylint
+          echo "PATH=$PATH" >> "$GITHUB_ENV"
 
       - name: Down coverage artifacts
         uses: actions/download-artifact@v5


### PR DESCRIPTION
When an artifact is uploaded, the folder it targets is not included in the zip. Thus, since it is just TiCS that needs this artifact, it is a bit easier to just move preparation work to after the coverage file is downloaded for the TiCS job.

Additionally, this PR attempts again to address issues with pylint and flake8, noting that they do appear to also be required for quality gate scans.