### PR TITLE
ci: Install test deps for TiCS and disable client mode

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,9 +5,6 @@ on:
     branches:
       - main
   pull_request:
-  schedule:
-    # Weekly scan
-    - cron: "20 4 * * 1"
 
 jobs:
   tests:
@@ -47,52 +44,3 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
           disable_search: true
-
-  tics:
-    name: "Run TiCS"
-    needs: tests
-    if: ${{ github.event_name != 'pull_request' }} # Disabled while we determine if we want to use client mode for PRs
-    runs-on: [self-hosted, amd64, tiobe, noble]
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v6
-        with:
-          enable-cache: true
-
-      - name: Install dependencies
-        run: |
-          uv sync --locked --all-extras --dev --all-groups
-          source .venv/bin/activate
-          uv pip install flake8 pylint
-          echo "PATH=$PATH" >> "$GITHUB_ENV"
-
-      - name: Down coverage artifacts
-        uses: actions/download-artifact@v5
-        with:
-          merge-multiple: true # There is only one artifact, but this removes the subfolder
-
-      - name: Prepare coverage report for TiCS
-        run: |
-          mkdir -p coverage
-          mv coverage.xml coverage/Cobertura.xml
-
-      - name: Determine TiCS run conditions
-        id: tics-condition
-        run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "tics_mode=client" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]] || [[ "${{ github.event_name }}" == "schedule" ]]; then
-            echo "tics_mode=qserver" >> $GITHUB_OUTPUT
-          fi
-
-      - name: "TiCS"
-        if: ${{ steps.tics-condition.outputs.tics_mode != '' }}
-        uses: tiobe/tics-github-action@v3
-        with:
-          mode: ${{ steps.tics-condition.outputs.tics_mode }}
-          project: ubuntu-insights-k8s-operator
-          viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
-          ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
-          installTics: true

--- a/.github/workflows/tics-scan.yaml
+++ b/.github/workflows/tics-scan.yaml
@@ -1,0 +1,79 @@
+name: TiCS Scan
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    # Weekly scan
+    - cron: "20 4 * * 1"
+
+jobs:
+  generate-coverage:
+    name: "Generate coverage report"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: "pyproject.toml"
+
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: |
+          uv tool install --python-preference only-managed tox --with tox-uv
+
+      - name: Run unit tests
+        run: |
+          tox -e unit
+
+      - name: Upload coverage artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: tics-${{ github.job }}-artifacts-${{ github.run_attempt }}
+          path: coverage.xml
+
+  tics:
+    name: "Run TiCS QServer"
+    needs: generate-coverage
+    runs-on: [self-hosted, amd64, tiobe, noble]
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: |
+          uv sync --locked --all-extras --dev --all-groups
+          source .venv/bin/activate
+          uv pip install flake8 pylint
+          echo "PATH=$PATH" >> "$GITHUB_ENV"
+
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@v5
+        with:
+          merge-multiple: true # There is only one artifact, but this removes the subfolder
+
+      - name: Prepare coverage report for TiCS
+        run: |
+          mkdir -p coverage
+          mv coverage.xml coverage/Cobertura.xml
+
+      - name: "TiCS"
+        uses: tiobe/tics-github-action@v3
+        with:
+          mode: qserver
+          project: ubuntu-insights-k8s-operator
+          viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
+          ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
+          installTics: true


### PR DESCRIPTION
This PR installs test dependencies for TiCS since it appears to be complaining about them, particularly Jubilant, even though the integration tests are marked as test code.

Additionally, following some discussion, I've disabled client mode from triggering by preventing the TiCS job from triggering on PRs. The amount of information exposed directly in GitHub isn't sufficient for comfortable use of the quality gate on open-source software, where it isn't guaranteed that the PR author will have access to our internal dashboards. As part of this, the TiCS scan job has been split into its own workflow.