### PR TITLE
ci: Add GitHub workflow to create PRs for charmlib updates

### DIFF
--- a/.github/workflows/charm-update-libs.yaml
+++ b/.github/workflows/charm-update-libs.yaml
@@ -1,0 +1,96 @@
+name: Update Charm Libraries
+on:
+  schedule:
+    # Weekly on Monday at 09:00 UTC
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  GIT_BRANCH: "auto/charm-libs"
+  CHARMCRAFT_CHANNEL: "latest/stable"
+
+jobs:
+  update-lib:
+    name: Check charm libraries
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash --noprofile --norc -euo pipefail {0}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Install charmcraft
+        run: |
+          sudo snap install charmcraft --classic --channel "${{ env.CHARMCRAFT_CHANNEL }}"
+
+      - name: Fetch charm libraries
+        id: fetch-libs
+        run: |
+          charmcraft fetch-lib
+
+      - name: Check diff
+        id: check-diff
+        run: |
+          changed_files=$(git diff --name-only && git ls-files --others --exclude-standard)
+
+          invalid_files=""
+          updated_libs=""
+
+          # Ensure only files in lib/charms/ are modified
+          for file in $changed_files; do
+            if [[ "$file" == "lib/charms/"* ]]; then
+              # File matches the pattern for charm libraries
+              updated_libs+="$file"$'\n'
+            else
+              # File does not match the pattern
+              invalid_files+="$file"$'\n'
+              echo "::error file=$(realpath "$file"),title=Unexpected-Diff::The file '$file' was modified, but it is not a charm library file."
+            fi
+          done
+
+          # Abort if invalid files were changed
+          if [[ -n "$invalid_files" ]]; then
+            exit 1
+          fi
+
+          # Create a multi-line output: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#multiline-strings
+          {
+            printf 'updated_libs<<EOF\n'
+            printf '%s' "$updated_libs"
+            printf 'EOF\n'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create a PR for local changes
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "deps(lib/charms): Update charm libraries"
+          title: "deps(lib/charms): Update charm libraries"
+          body: |
+            This is an automated pull request to fetch the latest charm libraries dependencies.
+
+            <details>
+              <summary>Updated Libraries</summary>
+
+              ```markdown
+              ${{ steps.check-diff.outputs.updated_libs }}
+              ```
+
+            </details>
+
+            Please do not modify the branch ${{ env.GIT_BRANCH }} directly. This branch is managed by an automated workflow.
+
+            Created by [workflow run #${{ github.run_id }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          labels: dependencies
+          add-paths: |
+            lib/charms/**
+          sign-commits: true
+          branch: "${{ env.GIT_BRANCH }}"
+          delete-branch: true


### PR DESCRIPTION
This PR introduces a CI workflow that fetches charmlib updates against main and creates a PR when necessary. This workflow is run weekly and can be dispatched manually. The commit is attributed to and signed by the default GitHub Actions bot.

Due to the nature of the action being used to create the pull request, it should be safe if there is an existing, unresolved PR when the action is run. The branch is deleted and the PR closed if it is determined that no changes are necessary.

The following image is an example of a PR that the workflow creates:
<img width="2656" height="1574" alt="image" src="https://github.com/user-attachments/assets/3fa77ae1-d3f8-4de9-b9b9-4c0de773b7f8" />

As a precaution, if any changes were made to files other than in `lib/charms`, the workflow fails and prints annotations pointing out the wrongly modified files:
<img width="2302" height="1158" alt="image" src="https://github.com/user-attachments/assets/e4c8816c-a8f9-4b3d-b812-11495360f65f" />

---
[UDENG-7776](https://warthogs.atlassian.net/browse/UDENG-7776)


[UDENG-7776]: https://warthogs.atlassian.net/browse/UDENG-7776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ