### PR TITLE
maint: Update the rock version with Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,17 @@
             ]
         },
         {
+            "groupName": "ubuntu-insights rockcraft version sync",
+            "groupSlug": "ubuntu-insights-rockcraft-version-sync",
+            "semanticCommitScope": "ubuntu-insights",
+            "matchManagers": [
+                "custom.regex"
+            ],
+            "matchPackageNames": [
+                "ubuntu/ubuntu-insights"
+            ]
+        },
+        {
             "enabled": false,
             "matchFileNames": [
                 "rockcraft.yaml"
@@ -42,6 +53,21 @@
             ],
             "matchStringsStrategy": "any",
             "versioningTemplate": "regex:^server/v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$"
+        },
+        {
+            "customType": "regex",
+            "datasourceTemplate": "github-tags",
+            "depNameTemplate": "ubuntu/ubuntu-insights",
+            "description": "Update rockcraft project version from Ubuntu Insights server tags",
+            "managerFilePatterns": [
+                "/(^|/)rockcraft.yaml$/"
+            ],
+            "matchStrings": [
+                "^version: \"(?<currentValue>\\d+\\.\\d+\\.\\d+)\"$"
+            ],
+            "extractVersionTemplate": "^server/v(?<version>\\d+\\.\\d+\\.\\d+)$",
+            "versioningTemplate": "semver",
+            "autoReplaceStringTemplate": "version: \"{{{newVersion}}}\""
         }
     ]
 }


### PR DESCRIPTION
Currently we update the ubuntu-insights git source tag with renovate. However, this doesn't update the rockcraft project version, which we are using to inject into the application itself.

Here, we expand the renovate config to also update the version. To prevent multiple PRs from being created for what is effectively one dependency, we group the two custom regex managers.