### PR TITLE
fix: update regex to correctly match version format in rockcraft project

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -63,7 +63,7 @@
                 "/(^|/)rockcraft.yaml$/"
             ],
             "matchStrings": [
-                "^version: \"(?<currentValue>\\d+\\.\\d+\\.\\d+)\"$"
+                "(^|\\n)version: \"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
             ],
             "extractVersionTemplate": "^server/v(?<version>\\d+\\.\\d+\\.\\d+)$",
             "versioningTemplate": "semver",


### PR DESCRIPTION
The old regex wasn't matching correctly. This is another attempt to get renovate to update the project version of the rock.