### PR TITLE
fix(renovate.json): update regex for version extraction in rockcraft project

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -63,11 +63,10 @@
                 "/(^|/)rockcraft.yaml$/"
             ],
             "matchStrings": [
-                "(^|\\n)version: \"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
+                "version: \"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
             ],
             "extractVersionTemplate": "^server/v(?<version>\\d+\\.\\d+\\.\\d+)$",
-            "versioningTemplate": "semver",
-            "autoReplaceStringTemplate": "version: \"{{{newVersion}}}\""
+            "versioningTemplate": "semver"
         }
     ]
 }


### PR DESCRIPTION
Third time is the charm? I wish there was an easier way to test Renovate configurations, but even in local mode, without dry-run, it stops just before creating the branches.