### PR TITLE
deps(uv): update setup-uv action to v8.0.0

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,7 @@ jobs:
           python-version-file: "pyproject.toml"
 
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
         with:
           enable-cache: true
 

--- a/.github/workflows/tics-scan.yaml
+++ b/.github/workflows/tics-scan.yaml
@@ -22,7 +22,7 @@ jobs:
           python-version-file: "pyproject.toml"
 
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
         with:
           enable-cache: true
 
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
         with:
           enable-cache: true
 


### PR DESCRIPTION
v8.0.0 is now immutable so it is ideal to use the githash as the ref.