### PR TITLE
fix(tox.ini): update pytest command to include integration tests path

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -77,7 +77,7 @@ commands =
     pytest -v \
            -x \
            --tb native \
-           --ignore={[vars]tests_path}/unit \
            --log-cli-level=INFO \
            -s \
-           {posargs}
+           {posargs} \
+           {[vars]tests_path}/integration


### PR DESCRIPTION
A new PyTest update broke compatibility with the loading of certain arguments due to a change in how conftest.py is loaded. Instead of ignoring unit tests, we now instead specify the correct root from the start.